### PR TITLE
UI fixes for Linux

### DIFF
--- a/app/GUI_PerformanceSimulationPage.cpp
+++ b/app/GUI_PerformanceSimulationPage.cpp
@@ -633,7 +633,7 @@ void SPFrame::OnDoPerformanceSimulation( wxCommandEvent &event)
             PopMessage("Simulation cancelled by user.", "Notice", wxICON_INFORMATION|wxOK);
             return;
         }
-        wxYieldIfNeeded();    //prevent GUI from freezing
+        // wxYieldIfNeeded();    //prevent GUI from freezing
     
         //Check if a layout is available for simulation
         if(_SF.getHeliostats()->size() == 0)

--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -1930,7 +1930,7 @@ void SPFrame::FluxProgressBase(int n_complete, int n_tot, wxGauge *active_gauge,
     else simprog = 0.;
     simprog = max(min(simprog,1.), 0.);
     active_gauge->SetValue(int(simprog*1000.));
-    wxYieldIfNeeded();    //prevent GUI from freezing
+    // wxYieldIfNeeded();    //prevent GUI from freezing
     active_gauge->Update();
     active_gauge->Refresh();
 }

--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -1515,11 +1515,12 @@ void SPFrame::OnMenuRunLayout( wxCommandEvent &WXUNUSED(evt) )
     _page_panel->SetActivePage( pageNames.simulations_layout );
     this->GetSizer()->Layout();
 
-    //update the button
-    wxCommandEvent newevent;
+    //Trigger the layout event as if the button were clicked
+    wxCommandEvent newevent( wxEVT_COMMAND_BUTTON_CLICKED );
+    newevent.SetId( _layout_button->GetId() );
     newevent.SetEventObject( _layout_button );
-    //do the layout
-    OnDoLayout( newevent );
+    _layout_button->GetEventHandler()->ProcessEvent(newevent);
+
 
 }
 
@@ -1530,9 +1531,12 @@ void SPFrame::OnMenuRunSimulation( wxCommandEvent &WXUNUSED(evt) )
         _page_panel->SetActivePage( pageNames.simulations_performance );
         this->GetSizer()->Layout();
 
-        wxCommandEvent newevent;
+        //Trigger the simulate event as if the button were clicked
+        wxCommandEvent newevent( wxEVT_COMMAND_BUTTON_CLICKED );
+        newevent.SetId( _flux_button->GetId() );
         newevent.SetEventObject( _flux_button );
-        OnDoPerformanceSimulation( newevent );
+        _flux_button->GetEventHandler()->ProcessEvent(newevent);
+
     }
     catch(std::exception &e)
     {
@@ -1930,9 +1934,11 @@ void SPFrame::FluxProgressBase(int n_complete, int n_tot, wxGauge *active_gauge,
     else simprog = 0.;
     simprog = max(min(simprog,1.), 0.);
     active_gauge->SetValue(int(simprog*1000.));
-    // wxYieldIfNeeded();    //prevent GUI from freezing
-    active_gauge->Update();
+
+    //Refresh (mark as dirty) and force update. Note that wxYield* variants cause the window to hang on linux here.
     active_gauge->Refresh();
+    active_gauge->Update();
+
 }
 
 int SPFrame::SolTraceProgressUpdate(st_uint_t ntracedtotal, st_uint_t ntraced, st_uint_t ntotrace, st_uint_t curstage, st_uint_t nstages, void *data)

--- a/app/InputControl.cpp
+++ b/app/InputControl.cpp
@@ -389,19 +389,6 @@ void InputControl::OnText( wxCommandEvent &WXUNUSED(event))
     _need_update = false;
 }
     
-void InputControl::OnBGPaintEvent( wxEraseEvent &event)
-{
-    event.Skip();
-}
-void InputControl::OnPaint( wxPaintEvent &event)
-{ 
-    this->Layout();
-        
-    Refresh(false);
-    event.Skip();
-}
-
-
 void InputControl::OnCombo( wxCommandEvent &event)
 {
     //handle combobox selection events
@@ -639,8 +626,7 @@ void InputControl::Build()
         if(!_text_only) bs->Add(st_units, 0, wxEXPAND|wxLEFT|wxTOP, 5);
         this->SetSizerAndFit(bs);
     }
-    this->Connect(wxEVT_ERASE_BACKGROUND, wxEraseEventHandler( InputControl::OnBGPaintEvent ), NULL, this);
-    this->Connect(wxEVT_PAINT, wxPaintEventHandler( InputControl::OnPaint ), NULL, this);
+
     this->Layout();
 }
 

--- a/app/InputControl.h
+++ b/app/InputControl.h
@@ -165,8 +165,6 @@ protected:
     void OnFile( wxCommandEvent &event);
     void OnFocus( wxFocusEvent &WXUNUSED(event));
     void OnLeaving( wxFocusEvent &event);
-    void OnBGPaintEvent( wxEraseEvent &event);
-    void OnPaint( wxPaintEvent &event);
     void OnMouseWheelSkip(wxCommandEvent &event); // catch mouse scroll events on combobox's here
     void Build();
 };

--- a/app/OutputControl.cpp
+++ b/app/OutputControl.cpp
@@ -190,7 +190,6 @@ void OutputControl::Build()
         bs->Add(st_units, 0, wxEXPAND|wxLEFT|wxTOP, 5);
     }
         
-    this->Connect(wxEVT_PAINT, wxPaintEventHandler( OutputControl::OnPaint ), NULL, this);
     this->SetSizerAndFit(bs);
     this->Layout();
     
@@ -222,12 +221,4 @@ void OutputControl::setVarObject(spbase* varobj)
 void OutputControl::setValue(int value)
 {
     tc->SetValue(my_to_string( value ));
-}
-
-void OutputControl::OnPaint( wxPaintEvent &event)
-{ 
-    this->Layout();
-        
-    Refresh(false);
-    event.Skip();
 }

--- a/app/OutputControl.h
+++ b/app/OutputControl.h
@@ -130,7 +130,6 @@ public:
 
 protected:
     void Build();
-    void OnPaint( wxPaintEvent &event);
 };
 
 #endif


### PR DESCRIPTION
Resolves several issues:
* Fixes #15. The performance simulation page and gauge were not switching appropriately due to event processing sequence problems. 
* Fixes #16. The custom InputControl and OutputControl widgets had overloads on the OnPaint method that were causing infinite redraw loops. This resulted in max CPU when pages with those controls were displayed, and also caused issues with the scrollbars on wxScrolledWindows containing these widgets. 