### PR TITLE
Variable dialog and insertion to scripting help function

### DIFF
--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -1522,6 +1522,11 @@ std::string SPFrame::GetVersionInfo()
     return _software_version;
 }
 
+wxFileName SPFrame::GetImageDir()
+{
+    return _image_dir;
+}
+
 void SPFrame::OnMenuRunLayout( wxCommandEvent &WXUNUSED(evt) )
 {
     //switch to the layout page

--- a/app/GUI_main.h
+++ b/app/GUI_main.h
@@ -692,7 +692,7 @@ public:
     optimization *GetOptimizationDataObject();
     void  SetScriptWindowPointer(SolarPILOTScriptWindow *p);
     std::string GetVersionInfo();
-
+    wxFileName GetImageDir();
 
     void UpdateHelioUITemplates();
     void UpdateReceiverUITemplates();


### PR DESCRIPTION
Fixes #34 

In the script window, the "Help" button now launches a variable selection dialog. Checked items will have their variable name inserted into the script at the cursor location. If the variable is a dropdown, the possible values from the dropdown are appended inside a comment.