### PR TITLE
multiple receiver flux constraint

### DIFF
--- a/app/GUI_OptimizationPage.cpp
+++ b/app/GUI_OptimizationPage.cpp
@@ -297,7 +297,7 @@ void SPFrame::OnDoOptimizationSimulation( wxCommandEvent &event )
             spvar<double> *varptr = static_cast<spvar<double>*>( V._varptrs.at( _opt_data.at(i).varname ) );
             optvars.at(i) = &varptr->val;
             vector<string> namedat = split(_opt_data.at(i).varname, ".");
-            names.at(i) = namedat.back();
+            names.at(i) = namedat.back() + "." + namedat.at(1);
             //bounds
             if( _opt_data.at(i).selections.at(0) == "none" )
                 lower.at(i) = -HUGE_VAL;

--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -629,7 +629,6 @@ void SPFrame::CreateInputPages(wxWindow *parent, PagePanel *pagepanel)
     _input_map.clear();
     _output_map.clear();
     //----
-    
     wxYieldIfNeeded();
 
     //Climate page
@@ -707,7 +706,6 @@ void SPFrame::CreateInputPages(wxWindow *parent, PagePanel *pagepanel)
 
     //Bind all of the input objects to handle changes in values
     bindControls();
-    
 }
 
 
@@ -1177,7 +1175,6 @@ void SPFrame::NewFile()
     //Set the change flag to false
     SetGeomState(false);
     _inputs_modified = false;
-
 
     //Notify the user
     PopMessage("New file created");

--- a/app/scripting.cpp
+++ b/app/scripting.cpp
@@ -863,7 +863,8 @@ static void _optimize( lk::invoke_t &cxt )
     int n_threads = F.GetThreadCount();
     ArrayString *local_wfdat = F.GetLocalWeatherDataObject();
     lk::vardata_t iter_vec;
-    std::vector< double > flux_vals, obj_vals;
+    std::vector< double > obj_vals;
+    std::vector< std::vector<double> > flux_vals;
     std::vector< std::vector< double > > eval_points;
 
     if(n_threads > 1)
@@ -952,11 +953,17 @@ static void _optimize( lk::invoke_t &cxt )
             iter_vec.vec()->at(i).vec_append( eval_points.at(i).at(j) );
         }
         iter_vec.vec()->at(i).vec_append( obj_vals.at(i) );
-        iter_vec.vec()->at(i).vec_append( flux_vals.at(i) );
+        for(size_t j=0; j<flux_vals.front().size(); j++)
+            iter_vec.vec()->at(i).vec_append( flux_vals.at(i).at(j) );
     }
 
+    lk::vardata_t fluxresult;
+    fluxresult.empty_vector();
+    for (size_t j = 0; j < flux_vals.back().size(); j++)
+        fluxresult.vec_append(flux_vals.back().at(j));
+
     cxt.result().hash_item( "objective", obj_vals.back() );
-    cxt.result().hash_item( "flux", flux_vals.back() );
+    cxt.result().hash_item( "flux", fluxresult);
     cxt.result().hash_item( "iterations", iter_vec );
 
 }


### PR DESCRIPTION
the receiver flux constraint during optimization was previously only applied to the first receiver. This commit applies the flux constraint to all receivers using an nlopt multi constraint

Fixes #48 