### PR TITLE
Project organization and script fixes

### DIFF
--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -264,7 +264,7 @@ SPFrame::SPFrame(wxWindow* parent, int id, const wxString& title, const wxPoint&
     //Set the version tag
 	_version_major = 1;
 	_version_minor = 3;
-	_version_patch = 9;
+	_version_patch = 91;
 
     _software_version = my_to_string(_version_major) + "." + my_to_string(_version_minor) + "." + my_to_string(_version_patch);
     _contact_info = "solarpilot.support@nrel.gov";

--- a/app/GUI_main.cpp
+++ b/app/GUI_main.cpp
@@ -264,7 +264,7 @@ SPFrame::SPFrame(wxWindow* parent, int id, const wxString& title, const wxPoint&
     //Set the version tag
 	_version_major = 1;
 	_version_minor = 3;
-	_version_patch = 8;
+	_version_patch = 9;
 
     _software_version = my_to_string(_version_major) + "." + my_to_string(_version_minor) + "." + my_to_string(_version_patch);
     _contact_info = "solarpilot.support@nrel.gov";
@@ -1512,6 +1512,11 @@ optimization *SPFrame::GetOptimizationDataObject()
 void SPFrame::SetScriptWindowPointer(SolarPILOTScriptWindow *p)
 {
     _active_script_window = p;
+}
+
+SolarPILOTScriptWindow* SPFrame::GetScriptWindowPointer()
+{
+    return _active_script_window;
 }
 
 std::string SPFrame::GetVersionInfo()

--- a/app/GUI_main.h
+++ b/app/GUI_main.h
@@ -693,6 +693,7 @@ public:
     parametric *GetParametricDataObject();
     optimization *GetOptimizationDataObject();
     void  SetScriptWindowPointer(SolarPILOTScriptWindow *p);
+    SolarPILOTScriptWindow* GetScriptWindowPointer();
     std::string GetVersionInfo();
     wxFileName GetImageDir();
 

--- a/app/param_dialog.cpp
+++ b/app/param_dialog.cpp
@@ -167,7 +167,7 @@ void par_variables_dialog::UpdateTree()
 
 }
 
-void par_variables_dialog::SetItems(var_map *V, int type_filter)
+void par_variables_dialog::SetItems(var_map *V, int type_filter, bool with_outputs)
 {
     
     m_items.clear();
@@ -205,7 +205,7 @@ void par_variables_dialog::SetItems(var_map *V, int type_filter)
     //populate lists
     for( unordered_map<string, spbase*>::iterator var=V->_varptrs.begin(); var != V->_varptrs.end(); var++)
     {
-        if( ! var->second->is_param || var->second->is_disabled || var->second->short_desc.empty() )
+        if( !(var->second->is_param || (var->second->is_output && with_outputs)) || var->second->is_disabled || var->second->short_desc.empty() )
             continue;
         string cname = (split(var->first, ".")).at(0);
         
@@ -229,7 +229,7 @@ void par_variables_dialog::SetItems(var_map *V, int type_filter)
     {
         spbase* var = V->_varptrs[all_names[i]];
 
-        if( ! var->is_param || var->short_desc.empty() || var->is_disabled)
+        if( ! (var->is_param || (var->is_output && with_outputs)) || var->short_desc.empty() || var->is_disabled)
             continue;
 
         if( type_filter != -1 )
@@ -239,7 +239,7 @@ void par_variables_dialog::SetItems(var_map *V, int type_filter)
         m_items.push_back(item_info());
         m_items.back().tree_id = 0;
         m_items.back().name = all_names[i];
-        m_items.back().label = var->short_desc;
+        m_items.back().label = var->short_desc + ((with_outputs && var->is_output) ? " [Output]" : "");
         m_items.back().shown = true;
         m_items.back().context = class_map[ (split(all_names[i], ".")).at(0) ];
         m_items.back().checked = false;

--- a/app/param_dialog.h
+++ b/app/param_dialog.h
@@ -105,7 +105,7 @@ public:
         long style=wxDEFAULT_DIALOG_STYLE|wxSTAY_ON_TOP|wxRESIZE_BORDER);
     
     void UpdateTree();
-    void SetItems(var_map *V, int type_filter = -1);
+    void SetItems(var_map *V, int type_filter = -1, bool with_outputs = false);
     void SetItems(const wxArrayStr &names, const wxArrayStr &labels, const wxArrayStr &contexts);
     wxArrayStr GetCheckedNames();
     int GetVarOptimizationType();

--- a/app/scripting.cpp
+++ b/app/scripting.cpp
@@ -1972,7 +1972,7 @@ void SolarPILOTScriptWindow::OnHelp( )
     wxFileName fn = SPFrame::Instance().GetImageDir();
 
     par_variables_dialog *dlg = new par_variables_dialog(this, wxID_ANY, fn.GetPath(true), false, wxT("Variable lookup"));
-    dlg->SetItems(V);
+    dlg->SetItems(V, -1, true); 
     
     dlg->SetSize(450, 550);
 

--- a/app/scripting.cpp
+++ b/app/scripting.cpp
@@ -1932,11 +1932,12 @@ SolarPILOTScriptWindow::SolarPILOTScriptWindow( wxWindow *parent, int id )
 
 SolarPILOTScriptWindow::~SolarPILOTScriptWindow()
 {
-    if(! SPFrame::Destroyed() )
+    if (!SPFrame::Destroyed())
+    {
         SPFrame::Instance().SetScriptWindowPointer(0);
-	
-	SPFrame::Instance().GetSolarFieldObject()->getSimInfoObject()->setCallbackFunction(_ui_default_callback, _ui_default_data);
 
+	    SPFrame::Instance().GetSolarFieldObject()->getSimInfoObject()->setCallbackFunction(_ui_default_callback, _ui_default_data);
+    }
 }
 
 void SolarPILOTScriptWindow::ScriptOutput(const char *msg)

--- a/app/scripting.cpp
+++ b/app/scripting.cpp
@@ -566,9 +566,43 @@ static void _generate_layout( lk::invoke_t &cxt )
     SF->Create(*V);
     bool ok = F.DoManagedLayout(*SF, *V);        //Returns TRUE if successful
 
+    sim_results& results = *F.GetResultsObject();
+    //Process the simulation results
+    results.clear();
+    results.resize(1);
+    double azzen[2];
+    SF->CalcDesignPtSunPosition(V->sf.sun_loc_des.mapval(), azzen[0], azzen[1]);
+
+    sim_params P;
+    P.dni = V->sf.dni_des.val;
+
+    results.at(0).process_analytical_simulation(*SF, P, 0, azzen);
+
+    //Load the results in the grid
+    F.UpdateLayoutGrid();
+
+
+    //Redraw the plots
+    F.GetFieldPlotObject()->SetPlotData(*SF, FIELD_PLOT::EFF_TOT);
+    //update the selection combo
+    F.UpdateFieldPlotSelections();
+    //update the receiver flux map selection combo
+    F.UpdateFluxPlotSelections();
+
+    F.DoResultsPage();
+
+    F.UpdateCalculatedGUIValues();
+    F.SetGeomState(false);
+    //F._inputs_modified = true;    //Any time the layout is run, flag for save on exit
+
+    //clear the flux heliostat list control
+    /*_flux_lc->ClearAll();
+    _flcsort.clear();*/
+    //UpdateFluxLC(-1);
+
     cxt.result().assign( ok );
 
-    F.UpdateLayoutGrid();
+    //F.UpdateLayoutGrid();
     F.GetFieldPlotObject()->SetPlotData( *SF, FIELD_PLOT::EFF_TOT ); 
     F.GetFieldPlotObject()->Update();
 

--- a/app/scripting.cpp
+++ b/app/scripting.cpp
@@ -272,14 +272,30 @@ static void _sp_var( lk::invoke_t &cxt )
             {
             case SP_INT:
             {
-                spvar<int> *v = static_cast< spvar<int>* >( var );
-                cxt.result().assign( (double)v->val );
+                if (var->is_output)
+                {
+                    spout<int>* v = static_cast<spout<int>*>(var);
+                    cxt.result().assign((double)v->Val());
+                }
+                else
+                {
+                    spvar<int> *v = static_cast< spvar<int>* >( var );
+                    cxt.result().assign( (double)v->val );
+                }
                 return;
             }
             case SP_DOUBLE:
             {
-                spvar<double> *v = static_cast< spvar<double>* >( var );
-                cxt.result().assign( v->val );
+                if (var->is_output)
+                {
+                    spout<double>* v = static_cast<spout<double>*>(var);
+                    cxt.result().assign(v->Val());
+                }
+                else
+                {
+                    spvar<double> *v = static_cast< spvar<double>* >( var );
+                    cxt.result().assign( v->val );
+                }
                 return;
             }
             case SP_STRING:
@@ -287,8 +303,16 @@ static void _sp_var( lk::invoke_t &cxt )
                 return;
             case SP_BOOL:
             {
-                spvar<bool> *v = static_cast< spvar<bool>* >( var );
-                cxt.result().assign( v->val ? 1. : 0. );
+                if (var->is_output)
+                {
+                    spout<bool>* v = static_cast<spout<bool>*>(var);
+                    cxt.result().assign(v->Val() ? 1. : 0.);
+                }
+                else
+                {
+                    spvar<bool> *v = static_cast< spvar<bool>* >( var );
+                    cxt.result().assign( v->val ? 1. : 0. );
+                }
                 return;
             }
             case SP_MATRIX_T:

--- a/app/scripting.h
+++ b/app/scripting.h
@@ -72,6 +72,8 @@ public:
     SolarPILOTScriptWindow( wxWindow *parent, int id = wxID_ANY );
     ~SolarPILOTScriptWindow();
     void ScriptOutput(const char *msg);
+    void EnableScriptWindowReporting(bool enabled=true);
+    bool IsReportingEnabled();
     
 protected:
     virtual void OnScriptStarted();
@@ -80,6 +82,7 @@ protected:
 
 	bool (*_ui_default_callback)(simulation_info*, void*);
 	void* _ui_default_data;
+    bool _reporting_enabled;
 };
 
 #endif

--- a/build_vs2017/SolarPILOT-UI.vcxproj
+++ b/build_vs2017/SolarPILOT-UI.vcxproj
@@ -81,19 +81,19 @@
   <PropertyGroup Label="Globals">
     <ProjectName>SolarPILOT-UI</ProjectName>
     <ProjectGuid>{94AE855F-2661-4492-8E9F-39A561A6E424}</ProjectGuid>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/build_vs2017/SolarPILOT-UI.vcxproj
+++ b/build_vs2017/SolarPILOT-UI.vcxproj
@@ -81,7 +81,7 @@
   <PropertyGroup Label="Globals">
     <ProjectName>SolarPILOT-UI</ProjectName>
     <ProjectGuid>{94AE855F-2661-4492-8E9F-39A561A6E424}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -154,10 +154,10 @@
       <AdditionalIncludeDirectories>$(WXMSW3)\lib\vc_x64_lib\mswud;$(WXMSW3)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>lpsolve.lib;lkx64d.lib;wexx64d.lib;nlopt.lib;shared.lib;coretrace.lib;solarpilot.lib;wxbase31ud_net.lib;wxbase31ud_xml.lib;wxmsw31ud_webview.lib;wxmsw31ud_adv.lib;wxmsw31ud_html.lib;wxmsw31ud_aui.lib;wxmsw31ud_stc.lib;wxmsw31ud_core.lib;wxmsw31ud_gl.lib;wxbase31ud.lib;wxscintillad.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;wsock32.lib;wininet.lib;libcurl.lib;winhttp.lib</AdditionalDependencies>
+      <AdditionalDependencies>lpsolved.lib;lkd.lib;wexd.lib;nloptd.lib;sharedd.lib;coretrace.lib;solarpilot.lib;wxbase31ud_net.lib;wxbase31ud_xml.lib;wxmsw31ud_webview.lib;wxmsw31ud_adv.lib;wxmsw31ud_html.lib;wxmsw31ud_aui.lib;wxmsw31ud_stc.lib;wxmsw31ud_core.lib;wxmsw31ud_gl.lib;wxbase31ud.lib;wxscintillad.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;wsock32.lib;wininet.lib;libcurl.lib;winhttp.lib</AdditionalDependencies>
       <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(ProjectDir)\build\$(Configuration)\$(Platform);$(ProjectDir)\build\$(Configuration)\$(Platform)\solarpilot;$(LKDIR);$(WEXDIR);$(WEXDIR)\build_vs2017\libcurl_ssl_x64\lib;$(SSCDIR)\build_vs2017\$(Platform)\$(Configuration);$(CORETRACEDIR)\build_vs2017\$(Platform)\$(Configuration);$(WXMSW3)\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)\build\$(Configuration)\$(Platform);$(ProjectDir)\build\$(Configuration)\$(Platform)\solarpilot;$(LKDIR);$(WEXDIR);$(SSCDIR)\build_vs2017\$(Platform)\$(Configuration);$(CORETRACEDIR)\build_vs2017\$(Platform)\$(Configuration);$(WXMSW3)\lib\vc_x64_lib;$(WEXDIR)\build_resources\libcurl_ssl_x64\lib;$(ProjectDir)\..\..\build\ssc\lpsolve\Debug;$(ProjectDir)\..\..\build\ssc\nlopt\Debug;$(ProjectDir)\..\..\build\lk\Debug;$(ProjectDir)\..\..\build\wex\Debug;$(ProjectDir)\..\..\build\ssc\shared\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(SolutionDir)\..\deploy\$(Platform)\$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>
@@ -194,10 +194,10 @@
       <AdditionalIncludeDirectories>$(WXMSW3)\lib\vc_x64_lib\mswu;$(WXMSW3)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>lpsolve.lib;lkx64.lib;nlopt.lib;shared.lib;coretrace.lib;solarpilot.lib;wxbase31u_net.lib;wxbase31u_xml.lib;wxmsw31u_webview.lib;wxmsw31u_adv.lib;wxmsw31u_html.lib;wxmsw31u_aui.lib;wxmsw31u_stc.lib;wxmsw31u_core.lib;wxbase31u.lib;wxscintilla.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;wsock32.lib;wininet.lib;wexx64.lib;%(AdditionalDependencies);libcurl.lib;winhttp.lib</AdditionalDependencies>
+      <AdditionalDependencies>lpsolve.lib;lk.lib;nlopt.lib;shared.lib;coretrace.lib;solarpilot.lib;wxbase31u_net.lib;wxbase31u_xml.lib;wxmsw31u_webview.lib;wxmsw31u_adv.lib;wxmsw31u_html.lib;wxmsw31u_aui.lib;wxmsw31u_stc.lib;wxmsw31u_core.lib;wxbase31u.lib;wxscintilla.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;wsock32.lib;wininet.lib;wex.lib;%(AdditionalDependencies);libcurl.lib;winhttp.lib</AdditionalDependencies>
       <OutputFile>$(TargetPath)</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <AdditionalLibraryDirectories>$(ProjectDir)\build\$(Configuration)\$(Platform);$(ProjectDir)\build\$(Configuration)\$(Platform)\solarpilot;$(LKDIR);$(WEXDIR);$(WEXDIR)\build_vs2017\libcurl_ssl_x64\lib;$(SSCDIR)\build_vs2017\$(Platform)\$(Configuration);$(CORETRACEDIR)\build_vs2017\$(Platform)\$(Configuration);$(WXMSW3)\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(ProjectDir)\..\..\build\ssc\lpsolve\Release;$(ProjectDir)\..\..\build\ssc\nlopt\Release;$(ProjectDir)\build\$(Configuration)\$(Platform);$(ProjectDir)\build\$(Configuration)\$(Platform)\solarpilot;$(LKDIR);$(WEXDIR);$(SSCDIR)\build_vs2017\$(Platform)\$(Configuration);$(CORETRACEDIR)\build_vs2017\$(Platform)\$(Configuration);$(WXMSW3)\lib\vc_x64_lib;$(WEXDIR)\build_resources\libcurl_ssl_x64\lib;$(ProjectDir)\..\..\build\lk\Release;$(ProjectDir)\..\..\build\wex\Release;$(ProjectDir)\..\..\build\ssc\shared\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ProgramDatabaseFile>$(SolutionDir)\..\deploy\$(Platform)\$(TargetName).pdb</ProgramDatabaseFile>
       <SubSystem>Windows</SubSystem>

--- a/build_vs2017/solarpilot.vcxproj
+++ b/build_vs2017/solarpilot.vcxproj
@@ -78,6 +78,7 @@
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/build_vs2017/solarpilot.vcxproj
+++ b/build_vs2017/solarpilot.vcxproj
@@ -11,79 +11,79 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\ssc\solarpilot\Ambient.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\API_structures.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\AutoPilot_API.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\definitions.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\exceptions.hpp" />
-    <ClInclude Include="..\..\ssc\solarpilot\Financial.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\Flux.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\fluxsim.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\heliodata.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\Heliostat.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\interop.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\IOUtil.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\Land.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\LayoutSimulateThread.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\mod_base.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\MultiRecOptimize.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\OpticalMesh.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\optimize.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\rapidxml.hpp" />
-    <ClInclude Include="..\..\ssc\solarpilot\rapidxml_iterators.hpp" />
-    <ClInclude Include="..\..\ssc\solarpilot\rapidxml_print.hpp" />
-    <ClInclude Include="..\..\ssc\solarpilot\rapidxml_utils.hpp" />
-    <ClInclude Include="..\..\ssc\solarpilot\Receiver.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\SolarField.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\solpos00.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\sort_method.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\STObject.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\string_util.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\STSimulateThread.h" />
-    <ClInclude Include="..\..\ssc\solarpilot\Toolbox.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Ambient.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\API_structures.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\AutoPilot_API.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\definitions.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\exceptions.hpp" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Financial.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Flux.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\fluxsim.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\heliodata.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Heliostat.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\interop.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\IOUtil.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Land.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\LayoutSimulateThread.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\mod_base.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\MultiRecOptimize.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\OpticalMesh.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\optimize.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\rapidxml.hpp" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\rapidxml_iterators.hpp" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\rapidxml_print.hpp" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\rapidxml_utils.hpp" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Receiver.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\SolarField.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\solpos00.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\sort_method.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\STObject.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\string_util.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\STSimulateThread.h" />
+    <ClInclude Include="$(SSCDIR)\solarpilot\Toolbox.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\ssc\solarpilot\Ambient.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\API_structures.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\AutoPilot_API.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\definitions.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Financial.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Flux.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\fluxsim.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\heliodata.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Heliostat.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\interop.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\IOUtil.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Land.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\LayoutSimulateThread.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\mod_base.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\MultiRecOptimize.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\OpticalMesh.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\optimize.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Receiver.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\SolarField.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\solpos.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\STObject.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\string_util.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\STSimulateThread.cpp" />
-    <ClCompile Include="..\..\ssc\solarpilot\Toolbox.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Ambient.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\API_structures.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\AutoPilot_API.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\definitions.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Financial.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Flux.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\fluxsim.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\heliodata.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Heliostat.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\interop.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\IOUtil.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Land.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\LayoutSimulateThread.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\mod_base.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\MultiRecOptimize.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\OpticalMesh.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\optimize.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Receiver.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\SolarField.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\solpos.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\STObject.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\string_util.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\STSimulateThread.cpp" />
+    <ClCompile Include="$(SSCDIR)\solarpilot\Toolbox.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CBA0DB61-80B0-4FCE-B4DA-1B4054582F87}</ProjectGuid>
     <RootNamespace>solarpilot</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -129,6 +129,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(CORETRACEDIR)/build_vs2017/$(Platform)/$(Configuration);$(SSCDIR)\build_vs2017\$(Platform)\$(Configuration);$(SSCDIR)\lpsolve;$(SSCDIR)\nlopt;$(SSCDIR)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>coretrace.lib;lpsolve.lib;nlopt.lib;shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/build_vs2017/solarpilot.vcxproj
+++ b/build_vs2017/solarpilot.vcxproj
@@ -71,17 +71,16 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{CBA0DB61-80B0-4FCE-B4DA-1B4054582F87}</ProjectGuid>
     <RootNamespace>solarpilot</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>

--- a/deploy/setup_script.iss
+++ b/deploy/setup_script.iss
@@ -21,8 +21,8 @@ ArchitecturesInstallIn64BitMode=x64
 
 
 ; UPDATE THESE TO MATCH THE VERSION
-AppVerName=SolarPILOT 1.3.8
-DefaultDirName={pf}\SolarPILOT\1.3.8
+AppVerName=SolarPILOT 1.3.9
+DefaultDirName={pf}\SolarPILOT\1.3.9
 
 AppPublisher=National Renewable Energy Laboratory
 AppPublisherURL=http://www.nrel.gov/csp/solarpilot.html


### PR DESCRIPTION
This PR includes a major change to the structure of build files and directories to support updated WEX, LK, and SSC build procedures based on cmake. The Wiki and readme will be updated in a following PR. 

Other specific updates include:
* adding an option to limit script log messages
* allowing retrieval of calculated parameters from the interface during script runs
* updating the layout script function to update all calculated parameters, mirroring the UI OnDoLayout call
* bug fix when closing the main SolarPILOT window with an LK window open
* displaying calculated and output variables in the script variable list dialog

The current installer is [here](https://pfs.nrel.gov/main.html?download&weblink=0a4ee9bfc60aae983edfdd14c61c0757&realfilename=solarpilot-install_1.3.91.exe)

Pairs with [mjwagner2/ssc commit 289a6df2...](https://github.com/mjwagner2/ssc/commit/289a6df2e0563bbad588da947e2a9fcc3f9dda55)

